### PR TITLE
"onload" parameter for the async_include template_tag, allowing calling a callback function

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
 Changes
 =======
 
+Version 0.6.8
+-------------
+* Feature: "onload" parameter for the async_include template_tag, allowing calling a callback function.
+
 Version 0.6.7
 -------------
 * Add some tests.

--- a/README.md
+++ b/README.md
@@ -115,6 +115,15 @@ need in your included template as named parameters of the **async_include** temp
 There is also a repository with a full example:
 [django-async-include-example](https://github.com/diegojromerolopez/django-async-include-example).
 
+## Call javascript function whe load is completed
+
+Pass the attribute `onload` with the name of the function you want to call after the request and the replacement
+has been completed. e.g.
+
+```html
+{% async_include "boards/components/view/current_percentage_of_completion.html" board=board onload="load_board_style" %}
+```
+
 ## Warning and limitations
 
 ### Object dynamic attributes

--- a/async_include/templates/async_include/template_tag.js
+++ b/async_include/templates/async_include/template_tag.js
@@ -42,6 +42,9 @@ document.addEventListener("DOMContentLoaded", function(event) {
             if(request_frequency == "once"){
                 document.getElementById(block_id).innerHTML = response_data;
                 document.getElementById(script_block_id).remove();
+                {% if onload_func %}
+                    {{onload_func}}();
+                {% endif %}
             }else{
                 document.getElementById(block_id).appendChild(
                     document.createTextNode(response_data)

--- a/async_include/templatetags/async_include.py
+++ b/async_include/templatetags/async_include.py
@@ -73,6 +73,11 @@ def async_include(context, template_path, *args, **kwargs):
     # Recurrent requests
     request__frequency = kwargs.pop('request__frequency', 'once')
 
+    # On load call this function
+    onload = kwargs.pop(
+        'onload', None
+    )
+
     replacements = {
         'template_path': template_path,
         'block_id': block_id,
@@ -81,6 +86,7 @@ def async_include(context, template_path, *args, **kwargs):
         'spinner__visible': spinner__visible,
         'spinner__template_path': spinner__template_path,
         'request__frequency': request__frequency,
+        'onload_func': onload,
         'context': {}
     }
 

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ for dirpath, dirnames, filenames in os.walk('.'):
 
 setup(
     name="django-async-include",
-    version="0.6.7",
+    version="0.6.8",
     author="Diego J. Romero López",
     author_email="diegojromerolopez@gmail.com",
     description=(


### PR DESCRIPTION
The main objective is to allow something like this:

```html
{% async_include "boards/components/view/current_percentage_of_completion.html" board=board onload="load_board_callback" %}

<script type="text/javascript">
     function load_board_callback(){
         console.log("board is loaded");
     }
</script>

```

